### PR TITLE
Fix typos in Querydsl repository methods

### DIFF
--- a/querydsl/src/main/java/study/querydsl/repository/MemberJpaRepository.java
+++ b/querydsl/src/main/java/study/querydsl/repository/MemberJpaRepository.java
@@ -108,14 +108,14 @@ public class MemberJpaRepository {
                         team.name.as("teamName")))
                 .from(member)
                 .leftJoin(member.team, team)
-                .where(usernemaEq(condition.getUsername()),
+                .where(usernameEq(condition.getUsername()),
                         teamNameEq(condition.getTeamName()),
-                        ageGeo(condition.getAgeGoe()),
+                        ageGoe(condition.getAgeGoe()),
                         ageLoe(condition.getAgeLoe()))
                 .fetch();
     }
 
-    private BooleanExpression usernemaEq(String username) {
+    private BooleanExpression usernameEq(String username) {
         return hasText(username) ? member.username.eq(username) : null;
     }
 
@@ -123,7 +123,7 @@ public class MemberJpaRepository {
         return hasText(teamName) ? team.name.eq(teamName) : null;
     }
 
-    private BooleanExpression ageGeo(Integer ageGoe) {
+    private BooleanExpression ageGoe(Integer ageGoe) {
         return ageGoe != null ? member.age.goe(ageGoe) : null;
     }
 

--- a/querydsl/src/main/java/study/querydsl/repository/MemberRepositoryCustomImpl.java
+++ b/querydsl/src/main/java/study/querydsl/repository/MemberRepositoryCustomImpl.java
@@ -43,9 +43,9 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
                         team.name.as("teamName")))
                 .from(member)
                 .leftJoin(member.team, team)
-                .where(usernemaEq(condition.getUsername()),
+                .where(usernameEq(condition.getUsername()),
                         teamNameEq(condition.getTeamName()),
-                        ageGeo(condition.getAgeGoe()),
+                        ageGoe(condition.getAgeGoe()),
                         ageLoe(condition.getAgeLoe()))
                 .fetch();
     }
@@ -65,9 +65,9 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
                         team.name.as("teamName")))
                 .from(member)
                 .leftJoin(member.team, team)
-                .where(usernemaEq(condition.getUsername()),
+                .where(usernameEq(condition.getUsername()),
                         teamNameEq(condition.getTeamName()),
-                        ageGeo(condition.getAgeGoe()),
+                        ageGoe(condition.getAgeGoe()),
                         ageLoe(condition.getAgeLoe()))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -93,9 +93,9 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
                         team.name.as("teamName")))
                 .from(member)
                 .leftJoin(member.team, team)
-                .where(usernemaEq(condition.getUsername()),
+                .where(usernameEq(condition.getUsername()),
                         teamNameEq(condition.getTeamName()),
-                        ageGeo(condition.getAgeGoe()),
+                        ageGoe(condition.getAgeGoe()),
                         ageLoe(condition.getAgeLoe()))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -105,9 +105,9 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
                 .select(member)
                 .from(member)
                 .leftJoin(member.team, team)
-                .where(usernemaEq(condition.getUsername()),
+                .where(usernameEq(condition.getUsername()),
                         teamNameEq(condition.getTeamName()),
-                        ageGeo(condition.getAgeGoe()),
+                        ageGoe(condition.getAgeGoe()),
                         ageLoe(condition.getAgeLoe()))
                 .fetchCount();
 
@@ -116,9 +116,9 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
                 .select(member)
                 .from(member)
                 .leftJoin(member.team, team)
-                .where(usernemaEq(condition.getUsername()),
+                .where(usernameEq(condition.getUsername()),
                         teamNameEq(condition.getTeamName()),
-                        ageGeo(condition.getAgeGoe()),
+                        ageGoe(condition.getAgeGoe()),
                         ageLoe(condition.getAgeLoe()));
 
         //return new PageImpl<>(content, pageable, total);
@@ -128,7 +128,7 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
 
     }
 
-    private BooleanExpression usernemaEq(String username) {
+    private BooleanExpression usernameEq(String username) {
         return hasText(username) ? member.username.eq(username) : null;
     }
 
@@ -136,7 +136,7 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
         return hasText(teamName) ? team.name.eq(teamName) : null;
     }
 
-    private BooleanExpression ageGeo(Integer ageGoe) {
+    private BooleanExpression ageGoe(Integer ageGoe) {
         return ageGoe != null ? member.age.goe(ageGoe) : null;
     }
 


### PR DESCRIPTION
## Summary
- fix typos `usernemaEq`->`usernameEq` and `ageGeo`->`ageGoe`
- update usages across repository implementations

## Testing
- `gradle test -q --no-daemon` *(fails: Plugin not found)*

------
https://chatgpt.com/codex/tasks/task_e_68401aa534ec832bb4c2d3b9746c3e00