### PR TITLE
Update QuerydslJoinTest comment

### DIFF
--- a/querydsl/src/test/java/study/querydsl/QuerydslJoinTest.java
+++ b/querydsl/src/test/java/study/querydsl/QuerydslJoinTest.java
@@ -85,7 +85,7 @@ public class QuerydslJoinTest {
 
     /**
      * ex) 회원과 팀을 조인하면서, 팀 이름이 teamA인 팀만 조인, 회원은 모두 조회
-     * JPQL : select m, t from Member m left join m.team t on t.nam = 'teamA'
+     * JPQL : select m, t from Member m left join m.team t on t.name = 'teamA'
      * SQL : select m.*, t.* from Member m left join Team t on m.TEAM_ID = t.id and t.name = 'teamA'
      */
     @Test


### PR DESCRIPTION
## Summary
- fix a typo in QuerydslJoinTest comment to refer to `t.name` instead of `t.nam`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68401c6b1294832bbc79c7e4ffc8a697