### PR TITLE
Fix null check in teamName specification

### DIFF
--- a/data-jpa/src/main/java/com/study/datajpa/repository/spec/MemberSpec.java
+++ b/data-jpa/src/main/java/com/study/datajpa/repository/spec/MemberSpec.java
@@ -12,7 +12,7 @@ public class MemberSpec {
             @Override
             public Predicate toPredicate(Root<Member> root, CriteriaQuery<?> query, CriteriaBuilder criteriaBuilder) {
 
-                if (StringUtils.hasText(teamName)) {
+                if (!StringUtils.hasText(teamName)) {
                     return null;
                 }
 


### PR DESCRIPTION
## Summary
- fix teamName specification so null is returned only when team name is absent

## Testing
- `gradle test --no-daemon` *(fails: Plugin org.springframework.boot could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68401c7687cc832ba1c365477f913467