### PR TITLE
Fix typo in OrderServiceTest

### DIFF
--- a/usingBootAndJPA/src/test/java/jpabook/jpashop/service/OrderServiceTest.java
+++ b/usingBootAndJPA/src/test/java/jpabook/jpashop/service/OrderServiceTest.java
@@ -79,7 +79,7 @@ public class OrderServiceTest {
         Order order = orderRepository.findOne(orderId);
 
         assertEquals("주문 취소시 상태는 CANCEL 이다", OrderStatus.CANCEL, order.getStatus());
-        assertEquals("주문 취소된 상픔은 재고가 원복되어야 한다.", 10, item.getStockQuantity());
+        assertEquals("주문 취소된 상품은 재고가 원복되어야 한다.", 10, item.getStockQuantity());
 
     }
 


### PR DESCRIPTION
## Summary
- fix Korean typo in `OrderServiceTest`

## Testing
- `./gradlew test` *(fails: unable to download Gradle distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68401c4668a0832b955433cb3e8b5326